### PR TITLE
inital project/server setup with test endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bitcoin-cosign"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+actix-web = "4.0.1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+reqwest = "0.11.10"
+
+[lib]
+name = "cosign"
+path = "src/lib/mod.rs"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # bitcoin-cosign
+
 A multi-signature collaborative custody service protecting user bitcoins

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,0 +1,17 @@
+use actix_web::dev::Server;
+use actix_web::{web, App, HttpResponse, HttpServer};
+use std::net::TcpListener;
+
+/// Ping: test endpoint to check the server is running
+async fn ping() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+/// Run the server
+pub fn run(listener: TcpListener) -> Result<Server, std::io::Error> {
+    let server = HttpServer::new(|| App::new().route("/ping", web::get().to(ping)))
+        .listen(listener)?
+        .run();
+
+    Ok(server)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,11 @@
+use cosign::run;
+use std::net::TcpListener;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port");
+    let port = listener.local_addr().unwrap().port();
+    println!("Starting bitcoin-cosign server on port: {}", port);
+
+    run(listener)?.await
+}

--- a/tests/ping.rs
+++ b/tests/ping.rs
@@ -1,0 +1,33 @@
+use std::net::TcpListener;
+
+use cosign;
+use reqwest;
+
+/// test the ping endpoint to confirm the server is running
+#[tokio::test]
+async fn ping_test() {
+    // 1. Arrange
+    let address = spawn_app();
+    let client = reqwest::Client::new();
+
+    // 2. Act
+    let response = client
+        .get(format!("{}/ping", &address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // 3. Assert
+    assert!(response.status().is_success());
+    assert_eq!(Some(0), response.content_length());
+}
+
+/// Spawn an instance of the application
+fn spawn_app() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port");
+    let port = listener.local_addr().unwrap().port();
+    let server = cosign::run(listener).expect("Failed to bind address");
+    let _ = tokio::spawn(server);
+
+    format!("http://127.0.0.1:{}", port)
+}


### PR DESCRIPTION
## What this PR does
- initial set up of the project/server
- adds a `/ping` test endpoint to health check the server