### PR TITLE
feat: child key derivation for users and service

### DIFF
--- a/migrations/20220513201906_create_addresses_table_if_not_exist.sql
+++ b/migrations/20220513201906_create_addresses_table_if_not_exist.sql
@@ -1,1 +1,0 @@
--- Add migration script here

--- a/migrations/20220513201907_create_addresses_table_if_not_exist.sql
+++ b/migrations/20220513201907_create_addresses_table_if_not_exist.sql
@@ -1,0 +1,18 @@
+-- Add migration script here
+
+-- Create addresses table
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS addresses(
+    id INT,
+    PRIMARY KEY (id),
+    user_id INT,
+    derivation_path TEXT NOT NULL,
+    child_pubk_1 TEXT NOT NULL,
+    child_pubk_2 TEXT NOT NULL,
+    service_pubk TEXT NOT NULL,
+    CONSTRAINT fk_users FOREIGN KEY(user_id) REFERENCES users(id)
+);
+
+COMMIT;

--- a/migrations/20220518144806_create_service_keys_table.sql
+++ b/migrations/20220518144806_create_service_keys_table.sql
@@ -1,0 +1,14 @@
+-- Add migration script here
+
+-- Create service_keys table
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS service_keys(
+    id INT,
+    PRIMARY KEY (id),
+    master_xpriv TEXT NOT NULL UNIQUE,
+    master_xpub TEXT NOT NULL UNIQUE
+);
+
+COMMIT;

--- a/migrations/20220518200423_update_mnemonics_in_service_keys_table.sql
+++ b/migrations/20220518200423_update_mnemonics_in_service_keys_table.sql
@@ -1,0 +1,19 @@
+-- Add migration script here
+
+BEGIN;
+
+CREATE SEQUENCE service_keys_id_sequence;
+
+ALTER TABLE
+    service_keys
+ALTER COLUMN
+    id
+SET
+    DEFAULT nextval('service_keys_id_sequence');
+
+ALTER TABLE
+    service_keys
+ADD
+    COLUMN mnemonic TEXT NOT NULL UNIQUE;
+
+COMMIT;

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -15,5 +15,7 @@ export DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@localhost:${DB_PORT}/${
 # sqlx migrate add create_users_table_if_not_exist
 # sqlx migrate add create_addresses_table_if_not_exist
 # sqlx migrate add create_service_keys_table
+# sqlx migrate add update_mnemonics_in_service_keys_table
+
 
 

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -14,5 +14,6 @@ export DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@localhost:${DB_PORT}/${
 # sqlx migrate add update_addresses_table_serial_id
 # sqlx migrate add create_users_table_if_not_exist
 # sqlx migrate add create_addresses_table_if_not_exist
+# sqlx migrate add create_service_keys_table
 
 

--- a/src/routes/addresses/gen_multisig_address.rs
+++ b/src/routes/addresses/gen_multisig_address.rs
@@ -1,52 +1,65 @@
-use std::{str::FromStr};
+use crate::domain::{GenerateAddressData, GenerateAddressResponse, Xpubs};
 use crate::utils::keys;
-use actix_web::{web::{self}, HttpResponse, http::header::ContentType};
-use sqlx::PgPool;
-use crate::domain::{ Xpubs, GenerateAddressData, GenerateAddressResponse };
-use bdk::{bitcoin::{Address, WScriptHash, util::bip32::ExtendedPubKey, hashes::sha256}, keys::ExtendedKey};
-use bdk::bitcoin::blockdata::opcodes::all::{OP_PUSHNUM_2, OP_PUSHNUM_3, OP_CHECKMULTISIG};
+use actix_web::{
+    http::header::ContentType,
+    web::{self},
+    HttpResponse,
+};
+use bdk::bitcoin::blockdata::opcodes::all::{OP_CHECKMULTISIG, OP_PUSHNUM_2, OP_PUSHNUM_3};
 use bdk::bitcoin::blockdata::script::Script;
 use bdk::bitcoin::hashes::Hash;
-use bdk::keys::bip39::Mnemonic; 
 use bdk::bitcoin::Network;
-
-
+use bdk::keys::bip39::Mnemonic;
+use bdk::{
+    bitcoin::{hashes::sha256, util::bip32::ExtendedPubKey, Address, WScriptHash},
+    keys::ExtendedKey,
+};
+use sqlx::PgPool;
+use std::str::FromStr;
+use std::sync::Arc;
 
 //generate 2-0f-3 multisig address from user supplied xpubs
-pub async fn gen_multisig_address(x_pubs: web::Json<Xpubs>, pool: web::Data<PgPool>)-> HttpResponse {
-
+pub async fn gen_multisig_address(
+    x_pubs: web::Json<Xpubs>,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
     //call the module that generates xpub;
-    let server_x_pub : String = service_generated_x_pub_key().await;
+    let server_x_pub: String = service_generated_x_pub_key().await;
     let x_server_pub_key = ExtendedPubKey::from_str(&server_x_pub.as_str()).unwrap();
     let user_x_pub_key_1 = ExtendedPubKey::from_str(x_pubs.x_pub_1.as_str()).unwrap();
     let user_x_pub_key_2 = ExtendedPubKey::from_str(x_pubs.x_pub_2.as_str()).unwrap();
 
-    let script_from_xpubs = generate_script(user_x_pub_key_1, user_x_pub_key_2, x_server_pub_key).await;
+    let script_from_xpubs =
+        generate_script(user_x_pub_key_1, user_x_pub_key_2, x_server_pub_key).await;
 
     let script_from_wt_hash = Script::new_v0_wsh(&script_from_xpubs);
 
     let address = Address::p2wsh(&script_from_wt_hash, Network::Regtest);
     //validate address
-   
-    let resp = GenerateAddressResponse::new("Address generated successfully", GenerateAddressData::new(&address));
-    
-    HttpResponse::Ok().content_type(ContentType::json()).json(&resp)
+
+    let resp = GenerateAddressResponse::new(
+        "Address generated successfully",
+        GenerateAddressData::new(&address),
+    );
+
+    HttpResponse::Ok()
+        .content_type(ContentType::json())
+        .json(&resp)
 }
 
-
-
-pub async fn generate_script(x_pub : ExtendedPubKey, x_pub_2: ExtendedPubKey,  service_x_pub: ExtendedPubKey) -> WScriptHash {
-
-   
-    let mut supplied_x_pub_byte = service_x_pub.public_key.to_bytes(); 
+pub async fn generate_script(
+    x_pub: ExtendedPubKey,
+    x_pub_2: ExtendedPubKey,
+    service_x_pub: ExtendedPubKey,
+) -> WScriptHash {
+    let mut supplied_x_pub_byte = service_x_pub.public_key.to_bytes();
     let mut user_x_pub_1 = x_pub.public_key.to_bytes();
     let mut user_x_pub_2 = x_pub_2.public_key.to_bytes();
-    
 
     // let p2wsh_hash = vec![OP_PUSHNUM_2.into_u8(), user_x_pub_1[0],  user_x_pub_2[0], supplied_x_pub_byte[0],  OP_PUSHNUM_3.into_u8(),  OP_CHECKMULTISIG.into_u8()];
-     // 1. Create an empty vector called script_byte
-     let mut script_byte = Vec::new();
-    
+    // 1. Create an empty vector called script_byte
+    let mut script_byte = Vec::new();
+
     // 2. Push op_2 to thescript_byte
     script_byte.push(OP_PUSHNUM_2.into_u8());
 
@@ -61,7 +74,6 @@ pub async fn generate_script(x_pub : ExtendedPubKey, x_pub_2: ExtendedPubKey,  s
     // 5. Push op_checkmultisig script_byte
     script_byte.push(OP_PUSHNUM_3.into_u8());
     script_byte.push(OP_CHECKMULTISIG.into_u8());
-    
 
     let hasher = sha256::Hash::hash(&script_byte);
 
@@ -74,35 +86,29 @@ pub async fn generate_script(x_pub : ExtendedPubKey, x_pub_2: ExtendedPubKey,  s
 
 // validate generated address
 // [TODO]- Implement proper validation of addresses
-pub fn validate_address(address: String) -> bool
-{
+pub fn validate_address(address: String) -> bool {
     if address.len() > 20 {
         true
-    }else {
+    } else {
         false
     }
 }
 
-pub async fn service_generated_x_pub_key () -> String {
-    let mnemonic:Mnemonic = keys::generate_mnemonic();
+pub async fn service_generated_x_pub_key() -> String {
+    let mnemonic: Mnemonic = keys::generate_mnemonic();
 
     let xtended_key: ExtendedKey = keys::generate_extended_key(&mnemonic);
 
     keys::generate_base58_xpub(xtended_key, Network::Regtest)
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
-    use crate::routes::addresses::{
-       generate_script
-    };
+    use crate::routes::addresses::generate_script;
     use bitcoin::util::bip32::ExtendedPubKey;
 
- 
     #[actix_rt::test]
     async fn generate_valid_script() {
         let x_pub_1 =  ExtendedPubKey::from_str(&"tpubD6NzVbkrYhZ4XubsZFiR1YuVq16dxAzt3hWYFtu1sEH7w1LN5gqJnWVtzqZVKrwSej6Pja8tLr4FvyQ9gUuthQ3HVPcfy9cLXhFRjBYMcR9".to_string()).unwrap();

--- a/src/routes/addresses/gen_multisig_address.rs
+++ b/src/routes/addresses/gen_multisig_address.rs
@@ -16,12 +16,11 @@ use bdk::{
 };
 use sqlx::PgPool;
 use std::str::FromStr;
-use std::sync::Arc;
 
 //generate 2-0f-3 multisig address from user supplied xpubs
 pub async fn gen_multisig_address(
     x_pubs: web::Json<Xpubs>,
-    pool: web::Data<PgPool>,
+    _pool: web::Data<PgPool>,
 ) -> HttpResponse {
     //call the module that generates xpub;
     let server_x_pub: String = service_generated_x_pub_key().await;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,6 +1,8 @@
 pub mod addresses;
+pub mod services;
 pub mod transactions;
 pub mod users;
 
-pub use users::{create::create_user, xpub::collect_xpub};
 pub use addresses::gen_multisig_address;
+pub use services::masterkeys;
+pub use users::{create::create_user, xpub::collect_xpub};

--- a/src/routes/services/masterkeys.rs
+++ b/src/routes/services/masterkeys.rs
@@ -78,7 +78,7 @@ pub async fn masterkeys(req: web::Json<RequestNetwork>, pool: web::Data<PgPool>)
                 msg: "SUCCESS: Master extended keys saved to database".to_string(),
                 status: StatusCode::OK.as_u16(),
             };
-            return HttpResponse::BadRequest().json(rsp_msg);
+            return HttpResponse::Ok().json(rsp_msg);
         }
         Err(e) => {
             let rsp_msg = MasterKeysResponse {

--- a/src/routes/services/masterkeys.rs
+++ b/src/routes/services/masterkeys.rs
@@ -1,0 +1,143 @@
+use crate::utils::{generate_service_master_keys, keys::ServiceMasterKeys};
+use actix_web::{http::StatusCode, web, HttpResponse};
+use bdk::bitcoin::Network;
+use sqlx::PgPool;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct RequestNetwork {
+    network: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct MasterKeysResponse {
+    msg: String,
+    status: u16,
+}
+
+pub struct MasterKeys {
+    pub master_xpriv: String,
+    pub master_xpub: String,
+}
+
+/// Generate service master keys and save a record to the database
+/// The request body: e.g. {"network": "bitcoin"}
+/// TODO: Authenticate this endpoint so that only internal requests from
+/// authenticated staff are authorized to call this endpoint
+pub async fn masterkeys(req: web::Json<RequestNetwork>, pool: web::Data<PgPool>) -> HttpResponse {
+    // 1. Generate service master keys
+    let network = match req.network.as_str() {
+        "bitcoin" => Network::Bitcoin,
+        "regtest" => Network::Regtest,
+        "testnet" => Network::Testnet,
+        "signet" => Network::Signet,
+        _ => {
+            let rsp = MasterKeysResponse {
+                msg: "ERROR: Invalid network. Enter one of 'bitcoin', 'regtest', 'testnet', 'signet'.".to_string(),
+                status: StatusCode::BAD_REQUEST.as_u16(),
+            };
+            return HttpResponse::BadRequest().json(rsp);
+        }
+    };
+
+    let masterkeys = generate_service_master_keys(network);
+
+    // 2. Check uniqueness of service master keys. If not unique, generate new keys
+    let existing_masterkeys = find_saved_service_masterkeys(&pool, &masterkeys).await;
+
+    match existing_masterkeys {
+        Ok(_key) => {
+            // 1. Generate new service keys
+            let new_masterkeys = generate_service_master_keys(network);
+            // 2. Save them to the database and return
+            match insert_service_masterkeys(&pool, &new_masterkeys).await {
+                Ok(_) => {
+                    let rsp_msg = MasterKeysResponse {
+                        msg: "SUCCESS: Master extended keys saved to database".to_string(),
+                        status: StatusCode::OK.as_u16(),
+                    };
+                    return HttpResponse::BadRequest().json(rsp_msg);
+                }
+                Err(e) => {
+                    let rsp_msg = MasterKeysResponse {
+                        msg: format!("ERROR: Error querying for master keys {:?}", e),
+                        status: StatusCode::BAD_REQUEST.as_u16(),
+                    };
+                    return HttpResponse::BadRequest().json(rsp_msg);
+                }
+            }
+        }
+        Err(e) => {
+            println!("{}", e);
+        }
+    }
+
+    // 3. Save to database
+    match insert_service_masterkeys(&pool, &masterkeys).await {
+        Ok(_) => {
+            let rsp_msg = MasterKeysResponse {
+                msg: "SUCCESS: Master extended keys saved to database".to_string(),
+                status: StatusCode::OK.as_u16(),
+            };
+            return HttpResponse::BadRequest().json(rsp_msg);
+        }
+        Err(e) => {
+            let rsp_msg = MasterKeysResponse {
+                msg: format!("ERROR: Error querying for master keys {:?}", e),
+                status: StatusCode::BAD_REQUEST.as_u16(),
+            };
+            return HttpResponse::BadRequest().json(rsp_msg);
+        }
+    }
+}
+
+/// Query the service_keys table for a saved record
+/// /// ***
+/// Parameters:
+///     pool (&PgPool): A shared reference to a Postgres connection pool
+///     service_masterkeys (&ServiceMasterKeys): A shared reference to a ServiceMasterKeys instance
+pub async fn find_saved_service_masterkeys(
+    pool: &PgPool,
+    service_masterkeys: &ServiceMasterKeys,
+) -> Result<MasterKeys, sqlx::Error> {
+    let keys = sqlx::query_as!(
+        MasterKeys,
+        r#"
+        SELECT master_xpriv, master_xpub FROM service_keys 
+        WHERE master_xpriv = ($1) and master_xpub = ($2)
+        "#,
+        service_masterkeys.xpriv,
+        service_masterkeys.xpub
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(keys)
+}
+
+/// Save master keys to service_keys table
+/// ***
+/// Parameters:
+///     pool (&PgPool): A shared reference to a Postgres connection pool
+///     service_masterkeys (&ServiceMasterKeys): A shared reference to a ServiceMasterKeys instance
+pub async fn insert_service_masterkeys(
+    pool: &PgPool,
+    service_masterkeys: &ServiceMasterKeys,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        INSERT INTO service_keys (mnemonic, master_xpriv, master_xpub)
+        VALUES ($1, $2, $3)
+        "#,
+        format!("{}", service_masterkeys.mnemonic),
+        service_masterkeys.xpriv,
+        service_masterkeys.xpub
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        println!("Failed to execute query: {:?}", e);
+        e
+    })?;
+
+    Ok(())
+}

--- a/src/routes/services/mod.rs
+++ b/src/routes/services/mod.rs
@@ -1,0 +1,3 @@
+pub mod masterkeys;
+
+pub use masterkeys::masterkeys;

--- a/src/routes/users/xpub.rs
+++ b/src/routes/users/xpub.rs
@@ -1,6 +1,6 @@
 use crate::domain::user_xpub::CollectXpub;
 use crate::domain::UserXpubs;
-use actix_web::{web, HttpResponse, http::StatusCode};
+use actix_web::{http::StatusCode, web, HttpResponse};
 use sqlx::PgPool;
 
 pub struct SavedUser {
@@ -23,7 +23,8 @@ pub async fn collect_xpub(req: web::Json<CollectXpub>, pool: web::Data<PgPool>) 
                 msg: format!("ERROR: Error parsing input. {}", e),
                 status: StatusCode::BAD_REQUEST.as_u16(),
             };
-            return HttpResponse::BadRequest().json(rsp_msg); },
+            return HttpResponse::BadRequest().json(rsp_msg);
+        }
     };
     // 2. Check if user email exists in DB
     // 2.1 If no record, return 40x
@@ -35,24 +36,27 @@ pub async fn collect_xpub(req: web::Json<CollectXpub>, pool: web::Data<PgPool>) 
                 status: StatusCode::BAD_REQUEST.as_u16(),
             };
             return HttpResponse::Forbidden().json(rsp_msg);
-        },
+        }
     };
     // 2.2 If a record exists, update the record with provided xpubs
     match update_user_xpubs(&pool, &user_xpubs).await {
         Ok(_) => {
             let rsp_msg = CollectXpubResponse {
-                msg: format!("Extended public keys for user {} sucessfully uploaded", existing_user.email),
+                msg: format!(
+                    "Extended public keys for user {} sucessfully uploaded",
+                    existing_user.email
+                ),
                 status: StatusCode::OK.as_u16(),
             };
             HttpResponse::Ok().json(rsp_msg)
-        },
+        }
         Err(e) => {
             let rsp_msg = CollectXpubResponse {
-                msg: format!("ERROR: Error update user record. {:?}", e),
+                msg: format!("ERROR: Error updating user record. {:?}", e),
                 status: StatusCode::BAD_REQUEST.as_u16(),
             };
             return HttpResponse::BadRequest().json(rsp_msg);
-        },
+        }
     }
 }
 
@@ -79,7 +83,7 @@ pub async fn find_saved_user(
 }
 
 /// Update database for saved user with provided xpubs
-/// /// ***
+/// ***
 /// Parameters:
 ///     pool (&PgPool): A shared reference to a Postgres connection pool
 ///     user_xpub (&UserXpubs): A shared reference to a UserXpubs instance

--- a/src/start_up.rs
+++ b/src/start_up.rs
@@ -1,5 +1,4 @@
-use crate::routes::{collect_xpub, create_user};
-use crate::routes::gen_multisig_address;
+use crate::routes::{collect_xpub, create_user, gen_multisig_address, masterkeys};
 use actix_web::dev::Server;
 use actix_web::{web, App, HttpResponse, HttpServer};
 use sqlx::PgPool;
@@ -19,6 +18,7 @@ pub fn run(listener: TcpListener, db_pool: PgPool) -> Result<Server, std::io::Er
             .route("/create_user", web::post().to(create_user))
             .route("/collect_xpubs", web::patch().to(collect_xpub))
             .route("/gen_multisig_addr", web::post().to(gen_multisig_address))
+            .route("/masterkeys", web::post().to(masterkeys))
             .app_data(db_pool.clone())
     })
     .listen(listener)?

--- a/src/utils/keys.rs
+++ b/src/utils/keys.rs
@@ -4,11 +4,10 @@ use bdk::keys::bip39::{Language, Mnemonic};
 use bdk::keys::{DerivableKey, ExtendedKey};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::util::base58::check_encode_slice;
-use bitcoin::util::bip32::ExtendedPrivKey;
+use bitcoin::util::bip32::{ExtendedPrivKey, ExtendedPubKey};
 use bitcoin::Network;
 use rand::random;
 
-/// Generate parent extended public key
 // 1. Generate mnemonic
 pub fn generate_mnemonic() -> Mnemonic {
     let english = Language::English;
@@ -36,13 +35,26 @@ pub fn generate_extended_key(mnemonic: &Mnemonic) -> ExtendedKey {
     xkey
 }
 
-// 4. Generate master private key from extended key
+// 4.1 Generate master private key from extended key
 pub fn generate_xpriv(xkey: ExtendedKey, network: Network) -> ExtendedPrivKey {
     let xpriv = xkey.into_xprv(network).unwrap();
     xpriv
 }
 
-// 5. Generate base58check-encoded master public key from master private key
+// 4.2 Generate base58 encoding of master private key from extended key
+pub fn generate_base58_xpriv(xkey: ExtendedKey, network: Network) -> String {
+    let xpriv = xkey.into_xprv(network).unwrap();
+    check_encode_slice(&xpriv.encode())
+}
+
+// 5.1 Generate master public key from master private key
+pub fn generate_xpub(xkey: ExtendedKey, network: Network) -> ExtendedPubKey {
+    let secp = Secp256k1::new();
+    let xpub = xkey.into_xpub(network, &secp);
+    xpub
+}
+
+// 5.2 Generate base58check-encoded master public key from master private key
 pub fn generate_base58_xpub(xkey: ExtendedKey, network: Network) -> String {
     let secp = Secp256k1::new();
     let xpub = xkey.into_xpub(network, &secp);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,8 +1,8 @@
-pub mod keys;
 pub mod address;
+pub mod keys;
 
 pub use keys::{
-    generate_base58_xpriv, generate_base58_xpub, generate_child_public_key, generate_extended_key,
+    generate_base58_xpriv, generate_base58_xpub, generate_child_xpub, generate_extended_key,
     generate_mnemonic, generate_seed_from_mnemonic, generate_xpriv, generate_xpub,
 };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,7 +3,8 @@ pub mod keys;
 
 pub use keys::{
     generate_base58_xpriv, generate_base58_xpub, generate_child_xpub, generate_extended_key,
-    generate_mnemonic, generate_seed_from_mnemonic, generate_xpriv, generate_xpub,
+    generate_mnemonic, generate_seed_from_mnemonic, generate_service_master_keys, generate_xpriv,
+    generate_xpub,
 };
 
 pub use address::connect_to_bitcoind;


### PR DESCRIPTION
## What this PR does?
- Adds child key generation functionality to the util module that is parametrized by index
- Adds a `/masterkeys` endpoint that is meant to be internal and allows the creation and saving of service master keys